### PR TITLE
[WIP] ch5 VI example using tiger image from ch3

### DIFF
--- a/markdown/ch5.markdown
+++ b/markdown/ch5.markdown
@@ -319,5 +319,19 @@ vi(auto_seg, human_seg)
 auto_seg = RAG_segmentation(seg, tiger, threshold=80)
 plt.imshow(color.label2rgb(auto_seg, tiger));
 
-vi(auto_seg, human_seg)
+vi(auto_seg, human_seg, ignore_x=[], ignore_y=[])
+```
+
+```python
+# Try many thresholds
+def vi_at_threshold(seg, tiger, human_seg, threshold):
+    auto_seg = RAG_segmentation(seg, tiger, threshold)
+    return(vi(auto_seg, human_seg, ignore_x=[], ignore_y=[]))
+
+thresholds = range(0,110,10)
+vi_per_threshold = [vi_at_threshold(seg, tiger, human_seg, threshold) for threshold in thresholds]
+```
+
+```python
+plt.plot(thresholds, vi_per_threshold);
 ```


### PR DESCRIPTION
To Do
- [x] load the tiger image from ch3
- [x] build the RAG
- [x] threshold it at various values
- [x] load the ground truth for that image
- [x] calculate VI
- [x] plot the VI vs the threshold chosen

Notes from @jni:
Ok so the last one is not so bad. In ch3, we kinda pick a "random" threshold and plot the resulting segmentation, right?
but why did we pick that threshold? The answer is that I eyeballed it. Which isn't very satisfying. Instead, one way to do it is to have a whole set of training images, estimate the error at every threshold, and, from then on, pick the threshold that on average minimises the error for the training images
so we are only doing a single round of that: threshold the graph, estimate the error (using the VI function in the example), and then repeat for all possible thresholds
and then you plot the value of the VI on the y axis vs the threshold on the x axis
