### PR TITLE
surround numbers with backticks in ch3 so build doesn't fail

### DIFF
--- a/markdown/ch3.markdown
+++ b/markdown/ch3.markdown
@@ -556,6 +556,7 @@ understand this difficulty, look at this image:
 
 While you see a face, a computer only sees a bunch of numbers:
 
+```
     58688888888888899998898988888666532121
     66888886888998999999899998888888865421
     66665566566689999999999998888888888653
@@ -594,6 +595,7 @@ While you see a face, a computer only sees a bunch of numbers:
     26686888888888888888888666688688865654
     28688888888888888888668666668686666555
     28666688888888888868668668688886665548
+```
 
 (Yes, your visual system is tuned enough to find faces that it sees the
 face even in this blob of numbers! But I hope you get my point. Also, check


### PR DESCRIPTION
Fixes this error (when making ch3):

```
(elegant)MCRI-N0307:elegant-scipy hdashnow$ make build_html/ch3.html 
notedown --timeout 300 --match python --run markdown/ch3.markdown --output build_ipynb/ch3.ipynb
Traceback (most recent call last):
  File "/Users/hdashnow/anaconda/envs/elegant/bin/notedown", line 11, in <module>
    sys.exit(app())
  File "/Users/hdashnow/anaconda/envs/elegant/lib/python3.4/site-packages/notedown/main.py", line 312, in app
    main(args, help=parser.format_help())
  File "/Users/hdashnow/anaconda/envs/elegant/lib/python3.4/site-packages/notedown/main.py", line 275, in main
    notebook = reader.read(ip, as_version=4)
  File "/Users/hdashnow/anaconda/envs/elegant/lib/python3.4/site-packages/nbformat/v4/rwbase.py", line 89, in read
    return self.reads(nbs, **kwargs)
  File "/Users/hdashnow/anaconda/envs/elegant/lib/python3.4/site-packages/notedown/notedown.py", line 376, in reads
    return self.to_notebook(s, **kwargs)
  File "/Users/hdashnow/anaconda/envs/elegant/lib/python3.4/site-packages/notedown/notedown.py", line 368, in to_notebook
    cells = self.create_cells(blocks)
  File "/Users/hdashnow/anaconda/envs/elegant/lib/python3.4/site-packages/notedown/notedown.py", line 347, in create_cells
    markdown_cell = self.create_markdown_cell(block)
  File "/Users/hdashnow/anaconda/envs/elegant/lib/python3.4/site-packages/notedown/notedown.py", line 323, in create_markdown_cell
    markdown_cell = nbbase.new_markdown_cell(**kwargs)
  File "/Users/hdashnow/anaconda/envs/elegant/lib/python3.4/site-packages/nbformat/v4/nbbase.py", line 112, in new_markdown_cell
    validate(cell, 'markdown_cell')
  File "/Users/hdashnow/anaconda/envs/elegant/lib/python3.4/site-packages/nbformat/v4/nbbase.py", line 23, in validate
    return validate(node, ref=ref, version=nbformat)
  File "/Users/hdashnow/anaconda/envs/elegant/lib/python3.4/site-packages/nbformat/validator.py", line 156, in validate
    raise better_validation_error(e, version, version_minor)
  File "/Users/hdashnow/anaconda/envs/elegant/lib/python3.4/site-packages/nbformat/validator.py", line 152, in validate
    return validator.validate(nbjson, {'$ref' : '#/definitions/%s' % ref})
  File "/Users/hdashnow/anaconda/envs/elegant/lib/python3.4/site-packages/jsonschema/validators.py", line 123, in validate
    raise error
jsonschema.exceptions.ValidationError: None is not valid under any of the given schemas

Failed validating 'oneOf' in schema['properties']['source']:
    {'oneOf': [{'type': 'string'},
               {'items': {'type': 'string'}, 'type': 'array'}]}

On instance['source']:
    None
make: *** [build_ipynb/ch3.ipynb] Error 1
```
