### PR TITLE
Update conda environment to resolve conflicts

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,10 +4,10 @@ dependencies:
 - numpy=1.11*
 - matplotlib=1.5*
 - astropy=1.1*
-- pandas=0.17*
+- pandas=0.18*
 - scipy=0.17*
 - scikit-learn=0.17*
-- scikit-image=0.11*
+- scikit-image=0.12*
 - networkx=1.10*
 - xlrd=0.9*
 - jupyter=1.0*


### PR DESCRIPTION
Pandas 0.17 is not available with Python 3.5 (it seems) (or somesuch). Anyway, the point is, I tried conda env create, and it failed, and this fixes it. =P
