### PR TITLE
[WIP] Style plots using our own MPL style file instead of ad-hoc

### DIFF
--- a/markdown/ch1.markdown
+++ b/markdown/ch1.markdown
@@ -614,7 +614,7 @@ def class_boxplot(data, classes, colors=None, **kwargs):
             kwargs.setdefault(key, {}).update(color=class2color[cls])
         # draw the boxplot
         box = ax.boxplot(class2data[cls], **kwargs)
-        lines.append(box['caps'][0])
+        lines.append(box['whiskers'][0])
     ax.legend(lines, all_classes)
     return ax
 ```

--- a/markdown/ch1.markdown
+++ b/markdown/ch1.markdown
@@ -469,6 +469,9 @@ KDE is commonly used to smooth out histograms, which gives a clearer picture of 
 import matplotlib.pyplot as plt
 # Use our own style file for the plots
 plt.style.use('style/elegant.mplstyle')
+# ignore MPL layout warnings
+import warnings
+warnings.filterwarnings('ignore', '.*Axes.*compatible.*tight_layout.*')
 ```
 
 ```python

--- a/markdown/ch1.markdown
+++ b/markdown/ch1.markdown
@@ -464,11 +464,11 @@ To visualize the distribution of total counts, we will use a kernel density esti
 KDE is commonly used to smooth out histograms, which gives a clearer picture of the underlying distribution.
 
 ```python
-%matplotlib inline
 # Make all plots appear inline in the Jupyter notebook from now onwards
-
+%matplotlib inline
 import matplotlib.pyplot as plt
-plt.style.use('ggplot') # Use ggplot style graphs for something a little prettier
+# Use our own style file for the plots
+plt.style.use('style/elegant.mplstyle')
 ```
 
 ```python
@@ -511,7 +511,7 @@ counts_subset = counts[:,samples_index]
 # Bar plot of expression counts by individual
 fig, ax = plt.subplots(figsize=(16,5))
 
-ax.boxplot(counts_subset, sym=".")
+ax.boxplot(counts_subset)
 ax.set_title("Gene expression counts raw")
 ax.set_xlabel("Individuals")
 ax.set_ylabel("Gene expression counts")
@@ -527,7 +527,7 @@ Both the log function and the n + 1 step can be done using broadcasting to simpl
 # Bar plot of expression counts by individual
 fig, ax = plt.subplots(figsize=(16,5))
 
-ax.boxplot(np.log(counts_subset + 1), sym=".")
+ax.boxplot(np.log(counts_subset + 1))
 ax.set_title("Gene expression counts raw")
 ax.set_xlabel("Individuals")
 ax.set_ylabel("log gene expression counts")
@@ -547,7 +547,7 @@ counts_subset_lib_norm = counts_lib_norm[:,samples_index]
 # Bar plot of expression counts by individual
 fig, ax = plt.subplots(figsize=(16,5))
 
-ax.boxplot(np.log(counts_subset_lib_norm + 1), sym=".")
+ax.boxplot(np.log(counts_subset_lib_norm + 1))
 ax.set_title("Gene expression counts normalized by library size")
 ax.set_xlabel("Individuals")
 ax.set_ylabel("log gene expression counts")
@@ -582,22 +582,16 @@ def class_boxplot(data, classes, colors=None, **kwargs):
         The color corresponding to each class. These will be cycled in
         the order in which the classes appear in `classes`. (So it is
         ideal to provide as many colors as there are classes! The
-        default palette contains five colors.)
+        default palette contains six colors.)
 
     Other parameters
     ----------------
     kwargs : dict
         Keyword arguments to pass on to `plt.boxplot`.
     """
-    # default boxplot parameters; only updated if not specified
-    kwargs.setdefault('sym', '.')
-    kwargs.setdefault('whiskerprops', {'linestyle': '-'})
-
-    # Set default color palette and map classes to colors
-    if colors is None:
-        colors = sns.xkcd_palette(["windows blue", "amber", "greyish",
-                                   "faded green", "dusty purple"])
     all_classes = sorted(set(classes))
+    if colors is None:
+        colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
     class2color = dict(zip(all_classes, it.cycle(colors)))
 
     # map classes to data vectors
@@ -691,7 +685,7 @@ def binned_boxplot(x, y,
     x_ticklabels = np.round(np.exp(x_bin_centers)).astype(int)
 
     # make the boxplot
-    ax.boxplot(binned_y, labels=x_ticklabels, sym=".")
+    ax.boxplot(binned_y, labels=x_ticklabels)
 
     # show only every 5th label to prevent crowding on x-axis
     plt.setp(ax.xaxis.get_ticklabels(), visible=False)

--- a/markdown/ch1.markdown
+++ b/markdown/ch1.markdown
@@ -486,7 +486,7 @@ density = stats.kde.gaussian_kde(total_counts)
 x = np.arange(min(total_counts), max(total_counts), 10000)
 
 # Make the density plot
-fig, ax = plt.subplots()
+fig, ax = plt.subplots(figsize=(8, 5))
 ax.plot(x, density(x))
 ax.set_xlabel("Total counts per individual")
 ax.set_ylabel("Density")
@@ -566,7 +566,6 @@ Once to divide all the gene expression counts by the total for that column, and 
 
 ```python
 import matplotlib.pyplot as plt
-import seaborn as sns
 import itertools as it
 from collections import defaultdict
 
@@ -606,7 +605,7 @@ def class_boxplot(data, classes, colors=None, **kwargs):
         class2data[cls][-1] = distrib
 
     # then, do each boxplot in turn with the appropriate color
-    fig, ax = plt.subplots()
+    fig, ax = plt.subplots(figsize=(2 * len(data), 5))
     lines = []
     for cls in all_classes:
         # set color for all elements of the boxplot

--- a/markdown/ch2.markdown
+++ b/markdown/ch2.markdown
@@ -115,11 +115,10 @@ def plot_col_density(data, xlabel=None):
     density_per_col = [stats.kde.gaussian_kde(col) for col in data.T] # Use gaussian smoothing to estimate the density
     x = np.linspace(np.min(data), np.max(data), 100)
 
-    plt.figure()
+    fig, ax = plt.subplots()
     for density in density_per_col:
-        plt.plot(x, density(x))
-    plt.xlabel(xlabel)
-    plt.show()
+        ax.plot(x, density(x))
+    ax.set_xlabel(xlabel)
 
 # Before normalization
 log_counts = np.log(counts + 1)
@@ -269,7 +268,6 @@ Whew! So that's a lot of information, but let's dive right in and hopefully you'
 First, we define a function, `bicluster`, that clusters both the rows *and* the columns of a matrix:
 
 ```python
-import matplotlib.pyplot as plt
 from scipy.cluster.hierarchy import linkage
 
 
@@ -312,6 +310,8 @@ This is difficult to avoid for plotting, where design is often a matter of eyeba
 
 ```python
 from scipy.cluster.hierarchy import dendrogram, leaves_list
+
+
 def plot_bicluster(data, row_linkage, col_linkage,
                    row_nclusters=10, col_nclusters=3):
     """Perform a biclustering, plot a heatmap with dendrograms on each axis.
@@ -372,8 +372,8 @@ def plot_bicluster(data, row_linkage, col_linkage,
     ax.set_yticks([])
 
     # Axis labels
-    plt.xlabel('Samples')
-    plt.ylabel('Genes', labelpad=125)
+    ax.set_xlabel('Samples')
+    ax.set_ylabel('Genes', labelpad=125)
 
     # Plot legend
     axcolor = fig.add_axes([0.91, 0.1, 0.02, 0.6])
@@ -492,7 +492,7 @@ def plot_cluster_survival_curves(clusters, sample_names, patients,
         If `True`, use `patients['melanoma-dead']` to right-censor the
         survival data.
     """
-    plt.figure()
+    fig, ax = plt.subplots()
     if type(clusters) == np.ndarray:
         cluster_ids = np.unique(clusters)
         cluster_names = ['cluster {}'.format(i) for i in cluster_ids]
@@ -513,11 +513,11 @@ def plot_cluster_survival_curves(clusters, sample_names, patients,
             censored = None
         stimes, sfracs = survival_distribution_function(survival_times,
                                                         censored)
-        plt.plot(stimes / 365, sfracs)
+        ax.plot(stimes / 365, sfracs)
 
-    plt.xlabel('survival time (years)')
-    plt.ylabel('fraction alive')
-    plt.legend(cluster_names)
+    ax.set_xlabel('survival time (years)')
+    ax.set_ylabel('fraction alive')
+    ax.legend(cluster_names)
 ```
 
 Now we can use the `fcluster` function to obtain cluster identities for the samples (columns of the counts data), and plot each survival curve separately.

--- a/markdown/ch2.markdown
+++ b/markdown/ch2.markdown
@@ -312,6 +312,13 @@ This is difficult to avoid for plotting, where design is often a matter of eyeba
 from scipy.cluster.hierarchy import dendrogram, leaves_list
 
 
+def clear_spines(axes):
+    for loc in ['left', 'right', 'top', 'bottom']:
+        axes.spines[loc].set_visible(False)
+    axes.set_xticks([])
+    axes.set_yticks([])
+
+
 def plot_bicluster(data, row_linkage, col_linkage,
                    row_nclusters=10, col_nclusters=3):
     """Perform a biclustering, plot a heatmap with dendrograms on each axis.
@@ -344,6 +351,7 @@ def plot_bicluster(data, row_linkage, col_linkage,
     threshold_r = (row_linkage[-row_nclusters, 2] +
                    row_linkage[-row_nclusters+1, 2]) / 2
     dendrogram(row_linkage, orientation='left', color_threshold=threshold_r)
+    clear_spines(ax1)
 
     # Compute and plot column-wise dendrogram
     # See notes above for explanation of parameters to `add_axes`
@@ -351,12 +359,7 @@ def plot_bicluster(data, row_linkage, col_linkage,
     threshold_c = (col_linkage[-col_nclusters, 2] +
                    col_linkage[-col_nclusters+1, 2]) / 2
     dendrogram(col_linkage, color_threshold=threshold_c)
-
-    # Hide axes labels
-    ax1.set_xticks([])
-    ax1.set_yticks([])
-    ax2.set_xticks([])
-    ax2.set_yticks([])
+    clear_spines(ax2)
 
     # Plot data heatmap
     ax = fig.add_axes([0.3, 0.1, 0.6, 0.6])
@@ -368,8 +371,7 @@ def plot_bicluster(data, row_linkage, col_linkage,
     data = data[:, idx_cols]
 
     im = ax.matshow(data, aspect='auto', origin='lower', cmap='YlGnBu_r')
-    ax.set_xticks([])
-    ax.set_yticks([])
+    clear_spines(ax)
 
     # Axis labels
     ax.set_xlabel('Samples')

--- a/markdown/ch2.markdown
+++ b/markdown/ch2.markdown
@@ -303,7 +303,7 @@ Simple: we just call `linkage` for the input matrix and also for the transpose o
 Next, we define a function to visualize the output of that clustering.
 We are going to rearrange the rows and columns of the input data so that similar rows are together and similar columns are together.
 And we are additionally going to show the merge tree for both rows and columns, displaying which observations belong together for each.
-The merge trees are presented as dendograms, with the branch-lengths indicating how similar the obvservations are to each other (shorter = more similar).
+The merge trees are presented as dendrograms, with the branch-lengths indicating how similar the obvservations are to each other (shorter = more similar).
 
 As a word of warning, there is a fair bit of hard-coding of parameters going on here.
 This is difficult to avoid for plotting, where design is often a matter of eyeballing to find the correct proportions.
@@ -345,7 +345,7 @@ def plot_bicluster(data, row_linkage, col_linkage,
                    row_linkage[-row_nclusters+1, 2]) / 2
     dendrogram(row_linkage, orientation='left', color_threshold=threshold_r)
 
-    # Compute and plot column-wise dendogram
+    # Compute and plot column-wise dendrogram
     # See notes above for explanation of parameters to `add_axes`
     ax2 = fig.add_axes([0.3, 0.71, 0.6, 0.2])
     threshold_c = (col_linkage[-col_nclusters, 2] +
@@ -361,7 +361,7 @@ def plot_bicluster(data, row_linkage, col_linkage,
     # Plot data heatmap
     ax = fig.add_axes([0.3, 0.1, 0.6, 0.6])
 
-    # Sort data by the dendogram leaves
+    # Sort data by the dendrogram leaves
     idx_rows = leaves_list(row_linkage)
     data = data[idx_rows, :]
     idx_cols = leaves_list(col_linkage)

--- a/markdown/ch2.markdown
+++ b/markdown/ch2.markdown
@@ -350,7 +350,9 @@ def plot_bicluster(data, row_linkage, col_linkage,
     # matrix.
     threshold_r = (row_linkage[-row_nclusters, 2] +
                    row_linkage[-row_nclusters+1, 2]) / 2
-    dendrogram(row_linkage, orientation='left', color_threshold=threshold_r)
+    with plt.rc_context({'lines.linewidth': 0.75}):
+        dendrogram(row_linkage, orientation='left',
+                   color_threshold=threshold_r, ax=ax1)
     clear_spines(ax1)
 
     # Compute and plot column-wise dendrogram
@@ -358,7 +360,8 @@ def plot_bicluster(data, row_linkage, col_linkage,
     ax2 = fig.add_axes([0.3, 0.71, 0.6, 0.2])
     threshold_c = (col_linkage[-col_nclusters, 2] +
                    col_linkage[-col_nclusters+1, 2]) / 2
-    dendrogram(col_linkage, color_threshold=threshold_c)
+    with plt.rc_context({'lines.linewidth': 0.75}):
+        dendrogram(col_linkage, color_threshold=threshold_c, ax=ax2)
     clear_spines(ax2)
 
     # Plot data heatmap

--- a/markdown/ch2.markdown
+++ b/markdown/ch2.markdown
@@ -67,7 +67,7 @@ We'll unpack that example throughout the chapter, but for now note that it illus
 %matplotlib inline
 
 import matplotlib.pyplot as plt
-plt.style.use('ggplot') # Use ggplot style graphs for something a little prettier
+plt.style.use('style/elegant.mplstyle')
 ```
 
 ### Get the data

--- a/markdown/ch3.markdown
+++ b/markdown/ch3.markdown
@@ -74,13 +74,7 @@ import numpy as np
 import matplotlib as mpl
 from matplotlib import pyplot as plt
 from matplotlib import cm  # colormap module
-```
-
-Next, we set the default matplotlib colormap and interpolation method:
-
-```python
-mpl.rcParams['image.cmap'] = 'gray'
-mpl.rcParams['image.interpolation'] = None
+plt.style.use('style/elegant.mplstyle')
 ```
 
 Finally, "make some noise" and display it as an image:
@@ -235,8 +229,9 @@ array of length 100. Suppose that after 30ms the light signal is turned on, and
 ```python
 sig = np.zeros(100, np.float) #
 sig[30:60] = 1  # signal = 1 during the period 30-60ms because light is observed
-plt.plot(sig);
-plt.ylim(-0.1, 1.1);
+fig, ax = plt.subplots()
+ax.plot(sig);
+ax.set_ylim(-0.1, 1.1);
 ```
 
 To find *when* the light is turned on, you can *delay* it by 1ms, then
@@ -252,8 +247,9 @@ only interested in pinpointing the time when the light was turned on, we can
 sigdelta = sig[1:]  # sigdelta[0] equals sig[1], and so on
 sigdiff = sigdelta - sig[:-1]
 sigon = np.clip(sigdiff, 0, np.inf)
-plt.plot(sigon)
-plt.ylim(-0.1, 1.1)
+fig, ax = plt.subplots()
+ax.plot(sigon)
+ax.set_ylim(-0.1, 1.1)
 print('Signal on at:', 1 + np.flatnonzero(sigon)[0], 'ms')
 ```
 
@@ -677,8 +673,7 @@ connected component from our `wormbrain` network:
 
 ```python
 sccs = nx.strongly_connected_component_subgraphs(wormbrain)
-sccs = sorted(sccs, key=len, reverse=True)
-giantscc = sccs[0]
+giantscc = max(sccs, key=len)
 print('The largest strongly connected component has %i nodes,' %
       giantscc.number_of_nodes(), 'out of %i total.' %
       wormbrain.number_of_nodes())
@@ -702,11 +697,11 @@ survival = 1 - cumfreq
 Then, plot using Matplotlib:
 
 ```python
-plt.loglog(np.arange(1, len(survival) + 1), survival, c='b', lw=2)
+plt.loglog(np.arange(1, len(survival) + 1), survival)
 plt.xlabel('in-degree distribution')
 plt.ylabel('fraction of neurons with higher in-degree distribution')
 plt.scatter(avg_in_degree, 0.0022, marker='v')
-plt.text(avg_in_degree - 0.5, 0.003, 'mean=%.2f' % avg_in_degree, )
+plt.text(avg_in_degree - 0.5, 0.003, 'mean=%.2f' % avg_in_degree)
 plt.ylim(0.002, 1.0)
 plt.show()
 ```

--- a/markdown/ch4.markdown
+++ b/markdown/ch4.markdown
@@ -47,11 +47,8 @@ suspects:
 ```python
 %matplotlib inline
 
-import seaborn as sns
-sns.set_style('white')
-sns.despine()
-
 import matplotlib.pyplot as plt
+plt.style.use('style/elegant.mplstyle')
 import numpy as np
 ```
 
@@ -490,7 +487,7 @@ image = io.imread('images/moonlanding.png')
 M, N = image.shape
 
 f, ax = plt.subplots(figsize=(10, 10))
-ax.imshow(image, cmap='gray')
+ax.imshow(image)
 
 print((M, N), image.dtype)
 ```
@@ -519,7 +516,7 @@ values, before displaying:
 f, ax = plt.subplots(figsize=(10, 10))
 
 ax.imshow(np.log(1 + F_magnitude),
-          cmap='viridis', interpolation='nearest',
+          cmap='viridis',
           extent=(-N // 2, N // 2, -M // 2, M // 2))
 ax.set_title('Spectrum magnitude')
 plt.show()
@@ -560,15 +557,14 @@ F_dim = F_dim * peaks.astype(int)
 image_filtered = np.real(fftpack.ifft2(F_dim))
 
 # And add a slight bit of blurring to soften the result
-from scipy import ndimage
-image_filtered = ndimage.gaussian_filter(image_filtered, sigma=1)
+from scipy import ndimage as ndi
+image_filtered = ndi.gaussian_filter(image_filtered, sigma=1)
 
 f, (ax0, ax1) = plt.subplots(2, 1, figsize=(20, 15))
-ax0.imshow(np.log10(1 + np.abs(F_dim)), cmap='gray', interpolation='nearest')
+ax0.imshow(np.log10(1 + np.abs(F_dim)))
 ax0.set_title('Spectrum after suppression')
 
-ax1.imshow(ndimage.gaussian_filter(image_filtered, sigma=1), cmap='gray',
-interpolation='nearest')
+ax1.imshow(ndi.gaussian_filter(image_filtered, sigma=1))
 ax1.set_title('Reconstructed image')
 
 plt.show()

--- a/markdown/ch5.markdown
+++ b/markdown/ch5.markdown
@@ -573,9 +573,9 @@ matrices.
 We'll use the following image as a test:
 
 ```python
-from skimage import data, io
+from skimage import data
 image = data.camera()
-io.imshow(image);
+plt.imshow(image);
 ```
 
 As a test operation, we'll be rotating the image by 30 degrees. We begin
@@ -729,7 +729,7 @@ Let's try it out!
 ```python
 tf = homography(H, image.shape)
 out = apply_transform(image, tf)
-io.imshow(out);
+plt.imshow(out);
 ```
 
 There's that rotation!
@@ -791,7 +791,7 @@ We can test that this works:
 
 ```python
 tf = transform_rotate_about_center(image.shape, 30)
-io.imshow(apply_transform(image, tf))
+plt.imshow(apply_transform(image, tf))
 ```
 
 <!-- solution end -->
@@ -1413,7 +1413,7 @@ from skimage import io
 url = 'http://www.eecs.berkeley.edu/Research/Projects/CS/vision/bsds/BSDS300/html/images/plain/normal/color/108073.jpg'
 tiger = io.imread(url)
 
-io.imshow(tiger);
+plt.imshow(tiger);
 ```
 
 In order to check our image segmentation, we're going to need a ground truth.
@@ -1431,7 +1431,7 @@ from skimage import color
 
 human_seg_url = 'http://www.eecs.berkeley.edu/Research/Projects/CS/vision/bsds/BSDS300/html/images/human/normal/outline/color/1122/108073.jpg'
 boundaries = io.imread(human_seg_url)
-io.imshow(boundaries);
+plt.imshow(boundaries);
 ```
 
 Overlaying the tiger image with the human segmentation, we can see that (unsurprisingly) this person does a pretty good job of finding the tiger.
@@ -1439,8 +1439,8 @@ They have also segmented out the river bank, and a tuft of reeds.
 Nice job, human #1122!
 
 ```python
-human_seg = nd.label(boundaries > 100)[0]
-io.imshow(color.label2rgb(human_seg, tiger));
+human_seg = ndi.label(boundaries > 100)[0]
+plt.imshow(color.label2rgb(human_seg, tiger));
 ```
 
 Now, let's grab our image segmentation code from chapter 3, and see how well a Python does a recognizing a tiger!
@@ -1460,11 +1460,11 @@ def add_edge_filter(values, graph):
 
 def build_rag(labels, image):
     g = nx.Graph()
-    footprint = nd.generate_binary_structure(labels.ndim, connectivity=1)
+    footprint = ndi.generate_binary_structure(labels.ndim, connectivity=1)
     for j in range(labels.ndim):
         fp = np.swapaxes(footprint, j, 0)
         fp[0, ...] = 0  # zero out top of footprint on each axis
-    _ = nd.generic_filter(labels, add_edge_filter, footprint=footprint,
+    _ = ndi.generic_filter(labels, add_edge_filter, footprint=footprint,
                           mode='nearest', extra_arguments=(g,))
     for n in g:
         g.node[n]['total color'] = np.zeros(3, np.double)
@@ -1486,7 +1486,7 @@ def threshold_graph(g, t):
 from skimage import segmentation
 seg = segmentation.slic(tiger, n_segments=30, compactness=40.0,
                         enforce_connectivity=True, sigma=3)
-io.imshow(color.label2rgb(seg, tiger));
+plt.imshow(color.label2rgb(seg, tiger));
 ```
 
 In chapter 3, we set the graph threshold at 80 and sort of hand-waved over the whole thing.

--- a/markdown/ch5.markdown
+++ b/markdown/ch5.markdown
@@ -1,7 +1,8 @@
 ```python
+# Set up plotting
 %matplotlib inline
 import matplotlib.pyplot as plt
-# Set up plotting
+plt.style.use('style/elegant.mplstyle')
 ```
 
 # Contingency tables using sparse coordinate matrices
@@ -572,9 +573,9 @@ matrices.
 We'll use the following image as a test:
 
 ```python
-from skimage import data
+from skimage import data, io
 image = data.camera()
-plt.imshow(image, cmap='gray');
+io.imshow(image);
 ```
 
 As a test operation, we'll be rotating the image by 30 degrees. We begin
@@ -728,7 +729,7 @@ Let's try it out!
 ```python
 tf = homography(H, image.shape)
 out = apply_transform(image, tf)
-plt.imshow(out, cmap='gray');
+io.imshow(out);
 ```
 
 There's that rotation!
@@ -790,7 +791,7 @@ We can test that this works:
 
 ```python
 tf = transform_rotate_about_center(image.shape, 30)
-plt.imshow(apply_transform(image, tf), cmap='gray')
+io.imshow(apply_transform(image, tf))
 ```
 
 <!-- solution end -->
@@ -1408,12 +1409,11 @@ example
 
 ```python
 from skimage import io
-from matplotlib import pyplot as plt
 
 url = 'http://www.eecs.berkeley.edu/Research/Projects/CS/vision/bsds/BSDS300/html/images/plain/normal/color/108073.jpg'
 tiger = io.imread(url)
 
-plt.imshow(tiger);
+io.imshow(tiger);
 ```
 
 In order to check our image segmentation, we're going to need a ground truth.
@@ -1426,7 +1426,7 @@ We have chosen a segmentation that we like (one with pedantic-reed-tracing, beca
 But to be clear, we really have no single ground truth!
 
 ```python
-from scipy import ndimage as nd
+from scipy import ndimage as ndi
 from skimage import color
 
 human_seg_url = 'http://www.eecs.berkeley.edu/Research/Projects/CS/vision/bsds/BSDS300/html/images/human/normal/outline/color/1122/108073.jpg'
@@ -1449,7 +1449,6 @@ Now, let's grab our image segmentation code from chapter 3, and see how well a P
 # Draw a region adjacency graph (RAG) - all code from Ch3
 import networkx as nx
 import numpy as np
-from scipy import ndimage as nd
 from skimage.future import graph
 
 def add_edge_filter(values, graph):

--- a/markdown/ch6.markdown
+++ b/markdown/ch6.markdown
@@ -402,7 +402,7 @@ functional "colorblind"
 [colorbrewer palette](http://chrisalbon.com/python/seaborn_color_palettes.html):
 
 ```python
-from matplotlib import colors
+from matplotlib.colors import ListedColormap
 
 
 def plot_connectome(x_coords, y_coords, conn_matrix, *,
@@ -435,7 +435,7 @@ def plot_connectome(x_coords, y_coords, conn_matrix, *,
         types = np.zeros(x_coords.shape, dtype=int)
     ntypes = len(np.unique(types))
     colors = plt.rcParams['axes.prop_cycle'][:ntypes].by_key()['color']
-    cmap = colors.ListedColormap(colors)
+    cmap = ListedColormap(colors)
 
     fig, ax = plt.subplots(**figkwargs)
 

--- a/markdown/ch6.markdown
+++ b/markdown/ch6.markdown
@@ -2,6 +2,8 @@
 
 ```python
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.style.use('style/elegant.mplstyle')
 ```
 
 Just like Chapter 4, which dealt with the Fast Fourier Transform, this chapter
@@ -229,7 +231,6 @@ second-smallest eigenvalue of $L$. Plotting the eigenvalues tells us which one
 is the second-smallest:
 
 ```python
-from matplotlib import pyplot as plt
 print(eigvals)
 plt.plot(eigvals, '-o')
 ```
@@ -401,10 +402,7 @@ functional "colorblind"
 [colorbrewer palette](http://chrisalbon.com/python/seaborn_color_palettes.html):
 
 ```python
-from matplotlib import pyplot as plt
 from matplotlib import colors
-
-import seaborn as sns  # for beautiful color palettes
 
 
 def plot_connectome(x_coords, y_coords, conn_matrix, *,
@@ -436,7 +434,8 @@ def plot_connectome(x_coords, y_coords, conn_matrix, *,
     if types is None:
         types = np.zeros(x_coords.shape, dtype=int)
     ntypes = len(np.unique(types))
-    cmap = colors.ListedColormap(sns.color_palette('colorblind', ntypes))
+    colors = plt.rcParams['axes.prop_cycle'][:ntypes].by_key()['color']
+    cmap = colors.ListedColormap(colors)
 
     fig, ax = plt.subplots(**figkwargs)
 

--- a/markdown/ch8.markdown
+++ b/markdown/ch8.markdown
@@ -1,5 +1,7 @@
 ```python
 %matplotlib inline
+import matplotlib.pyplot as plt
+plt.style.use('style/elegant.mplstyle')
 ```
 # Big Data in Little Laptop with Toolz
 
@@ -345,21 +347,20 @@ This totally works and is streaming, so reads are loaded from disk one at a time
 We can then plot a histogram of the counts, and confirm that there are indeed two well-separated populations of correct and erroneous k-mers:
 
 ```python
-from matplotlib import pyplot as plt
-
 def integer_histogram(counts, normed=True, xlim=[], ylim=[],
                       *args, **kwargs):
     hist = np.bincount(counts)
     if normed:
         hist = hist / np.sum(hist)
-    plt.plot(np.arange(hist.size), hist, *args, **kwargs)
-    plt.xlabel('counts')
-    plt.ylabel('frequency')
-    plt.xlim(*xlim)
-    plt.ylim(*ylim)
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(hist.size), hist, *args, **kwargs)
+    ax.set_xlabel('counts')
+    ax.set_ylabel('frequency')
+    ax.set_xlim(*xlim)
+    ax.set_ylim(*ylim)
 
 counts_arr = np.fromiter(counts.values(), dtype=int, count=len(counts))
-integer_histogram(counts_arr, xlim=(-1, 250), lw=2)
+integer_histogram(counts_arr, xlim=(-1, 250))
 ```
 
 Notice the nice distribution of k-mer frequencies, along with a big bump of k-mers (at the left of the plot) that appear only once.
@@ -596,7 +597,6 @@ print(components.shape)
 We can now plot the components:
 
 ```python
-from matplotlib import pyplot as plt
 plt.scatter(*components.T)
 ```
 
@@ -747,9 +747,11 @@ print(model)
 It's probably clearer to look at the result as an image:
 
 ```python
-plt.imshow(model, cmap='gist_heat', interpolation='nearest');
-plt.colorbar();
-ax = plt.gca()
+fig = plt.figure()
+ax = fig.add_axes([0.1, 0.1, 0.8, 0.8])
+im = ax.imshow(model, cmap='magma');
+axcolor = fig.add_axes([0.91, 0.1, 0.02, 0.8])
+plt.colorbar(im, cax=axcolor)
 ax.set_xticklabels(' ACGTacgt');
 ax.set_yticklabels(' ACGTacgt');
 ```

--- a/style/elegant.mplstyle
+++ b/style/elegant.mplstyle
@@ -7,9 +7,8 @@ lines.linewidth: 2
 axes.prop_cycle: cycler('color', ['0072b2', '009e73', 'd55e00', 'cc79a7', 'f0e442', '56b4e9', '0072b2'])
 
 # Remove the right and top axis spines
-axes.spine.left: true
-axes.spine.bottom: true
-axes.spine.top: false
-axes.spine.right: false
-
+axes.spines.left: true
+axes.spines.bottom: true
+axes.spines.top: false
+axes.spines.right: false
 

--- a/style/elegant.mplstyle
+++ b/style/elegant.mplstyle
@@ -12,3 +12,30 @@ axes.spines.bottom: true
 axes.spines.top: false
 axes.spines.right: false
 
+# Use thicker axes
+axes.linewidth: 1.5
+
+# Remove ticks
+xtick.major.size: 0
+xtick.minor.size: 0
+xtick.labelsize: large
+ytick.major.size: 0
+ytick.minor.size: 0
+ytick.labelsize: large
+
+# Remove grids
+grid.linewidth: 0
+
+# Remove box around legend
+# Use 3 scatter points in points legend
+# Use large font in legend
+legend.frameon: false
+legend.scatterpoints: 3
+legend.fontsize: large
+
+figure.dpi: 300
+figure.facecolor: 1.0
+figure.autolayout: true
+
+image.interpolation: nearest
+image.cmap: gray

--- a/style/elegant.mplstyle
+++ b/style/elegant.mplstyle
@@ -39,3 +39,8 @@ figure.autolayout: true
 
 image.interpolation: nearest
 image.cmap: gray
+
+# Box plots
+boxplot.whiskerprops.linestyle: -
+boxplot.whiskerprops.linewidth: 2
+boxplot.flierprops.marker: .

--- a/style/elegant.mplstyle
+++ b/style/elegant.mplstyle
@@ -1,0 +1,15 @@
+# Elegant SciPy Matplotlib Style
+# Author: Juan Nunez-Iglesias
+
+lines.linewidth: 2
+
+# Use the Seaborn Colorblind palette for color cycles
+axes.prop_cycle: cycler('color', ['#0072b2', '#009e73', '#d55e00', '#cc79a7', '#f0e442', '#56b4e9', '#0072b2'])
+
+# Remove the right and top axis spines
+axes.spine.left: true
+axes.spine.bottom: true
+axes.spine.top: false
+axes.spine.right: false
+
+

--- a/style/elegant.mplstyle
+++ b/style/elegant.mplstyle
@@ -12,6 +12,9 @@ axes.spines.bottom: true
 axes.spines.top: false
 axes.spines.right: false
 
+# Use large font for axis labels
+axes.labelsize: large
+
 # Use thicker axes
 axes.linewidth: 1.5
 
@@ -33,9 +36,9 @@ legend.frameon: false
 legend.scatterpoints: 3
 legend.fontsize: large
 
-figure.dpi: 300
 figure.facecolor: 1.0
-figure.autolayout: true
+figure.autolayout: false
+savefig.dpi: 300
 
 image.interpolation: nearest
 image.cmap: gray

--- a/style/elegant.mplstyle
+++ b/style/elegant.mplstyle
@@ -42,6 +42,7 @@ savefig.dpi: 300
 
 image.interpolation: nearest
 image.cmap: gray
+image.resample: false
 
 # Box plots
 boxplot.whiskerprops.linestyle: -

--- a/style/elegant.mplstyle
+++ b/style/elegant.mplstyle
@@ -45,6 +45,14 @@ image.cmap: gray
 image.resample: false
 
 # Box plots
-boxplot.whiskerprops.linestyle: -
-boxplot.whiskerprops.linewidth: 2
 boxplot.flierprops.marker: .
+boxplot.flierprops.markerfacecolor: 0072b2
+boxplot.flierprops.markeredgecolor: 0072b2
+boxplot.boxprops.color: 0072b2
+boxplot.boxprops.linewidth: 2
+boxplot.whiskerprops.linestyle: -
+boxplot.whiskerprops.color: 0072b2
+boxplot.whiskerprops.linewidth: 2
+boxplot.capprops.linewidth: 0
+boxplot.medianprops.linewidth: 2
+boxplot.medianprops.color: d55e00

--- a/style/elegant.mplstyle
+++ b/style/elegant.mplstyle
@@ -4,7 +4,7 @@
 lines.linewidth: 2
 
 # Use the Seaborn Colorblind palette for color cycles
-axes.prop_cycle: cycler('color', ['#0072b2', '#009e73', '#d55e00', '#cc79a7', '#f0e442', '#56b4e9', '#0072b2'])
+axes.prop_cycle: cycler('color', ['0072b2', '009e73', 'd55e00', 'cc79a7', 'f0e442', '56b4e9', '0072b2'])
 
 # Remove the right and top axis spines
 axes.spine.left: true


### PR DESCRIPTION
**Don't merge this yet,** I'm putting it up here for discussion.

We've been setting plot styles in with various changes to plt.rcParams, keyword arguments, or plt.style.use('ggplot'), which doesn't please many, and completely inconsistently throughout the book. As pointed out by @NelleV, the correct way to do this is with our own style file. This begins that work.

Key questions:
- do people like my preference (inspired by prettyplotlib) of removing the right and top spines of plots?
- if yes, well, it turns out that mpl complains when there are no right/top spines but you use auto_layout. Should we ignore the warnings, or turn off autolayout?
- thicker axes and big fonts work well in general but they look terrible for imshow. I don't know of a way to change axes properties specifically for imshow, but keep an eye out on the [mailing list](https://mail.python.org/pipermail/matplotlib-users/2016-November/000678.html).
- scatter() doesn't respect the color cycle property in 1.5, but will in 2.0 [ref](https://mail.python.org/pipermail/matplotlib-users/2016-November/000677.html). Do we bump our dependency up to 2.0?