### PR TITLE
Use Ward in biclustering for better clusters

### DIFF
--- a/markdown/ch2.markdown
+++ b/markdown/ch2.markdown
@@ -391,7 +391,8 @@ Now we apply these functions to our normalized counts matrix to display row and 
 ```python
 counts_log = np.log(counts + 1)
 counts_var = most_variable_rows(counts_log, n=1500)
-yr, yc = bicluster(counts_var)
+yr, yc = bicluster(counts_var, linkage_method='ward',
+                   distance_metric='euclidean')
 plot_bicluster(counts_var, yr, yc)
 ```
 


### PR DESCRIPTION
This appears to offer a slight improvement in the predictive capability of the clustering:

<img width="998" alt="screen shot 2016-12-09 at 12 50 25 am" src="https://cloud.githubusercontent.com/assets/492549/21012328/8c69a826-bda9-11e6-9fb9-293b9d629d84.png">

Not sure yet whether this should be merged. Possibly it needs a bit more experimentation and polishing. (e.g. I think we should pick a parameter and hardcode it — the complexity of an API doesn't belong in the book.)