### PR TITLE
Cleanups for chapters 1, 2, 4

### DIFF
--- a/markdown/ch1.markdown
+++ b/markdown/ch1.markdown
@@ -691,7 +691,7 @@ So if a gene is twice as long, we are twice as likely to sample it.
 Let's see if the relationship between gene length and counts plays out in our data set.
 
 ```python
-def binned_boxplot(x, y, *,      # check out this Python 3-exclusive *! (see tip box)
+def binned_boxplot(x, y, *,  # check out this Python 3 exclusive! (*see tip box)
                    xlabel='gene length (log scale)',
                    ylabel='average log counts'):
     """Plot the distribution of `y` dependent on `x` using many boxplots.
@@ -741,40 +741,37 @@ def binned_boxplot(x, y, *,      # check out this Python 3-exclusive *! (see tip
 
 
 
-TODO: make this a tip box. Code currently doesn't run using the ">" notedown format.
-Also, can't have code with a deliberate error in it or it crashes the whole thing.
-
-**Tip Box: Python 3-exclusive: using '*' to create Keyword-Only Arguments**
-
-Since version 3.0 Python has enabled us to create
-["keyword-only" arguments](https://www.python.org/dev/peps/pep-3102/).
-These are arguments that you have to call using a keyword, you can't rely on position alone.
-For example, in the `binned_boxplot` function we just wrote, you could call it like this:
-```
-binned_boxplot(x, y, xlabel='my x label', ylabel='my y label')
-```
-but not like this:
-```
-binned_boxplot(x, y, 'my x label', 'my y label')
-
----------------------------------------------------------------------------
-TypeError                                 Traceback (most recent call last)
-<ipython-input-58-7a118d2d5750in <module>()
-      1 x_vals = [1, 2, 3, 4, 5]
-      2 y_vals = [1, 2, 3, 4, 5]
-----3 binned_boxplot(x, y, 'my x label', 'my y label')
-
-TypeError: binned_boxplot() takes 2 positional arguments but 4 were given
-```
-The idea is to prevent you from accidentally doing something like this:
-```
-binned_boxplot(x, y, 'my y label')
-```
-Which would give you your y label on the x axis.
-
-This strategy because particularly useful when you are using a function that
-has lots of arguments, where the positions aren't particularly meaningful
-(as, let's face it, is the case most of the time).
+> ## Python 3 Tip: using `*` to create keyword-only arguments {.callout}
+>
+> Since version 3.0 Python allows
+> ["keyword-only" arguments](https://www.python.org/dev/peps/pep-3102/).
+> These are arguments that you have to call using a keyword, rather than relying
+> on position alone.
+> For example, with the `binned_boxplot` function we just wrote, you can call it
+> like this:
+>
+>     >>> binned_boxplot(x, y, xlabel='my x label', ylabel='my y label')
+>
+> but not this, which would have been valid Python 2, raises an error in
+> Python 3:
+>
+>     >>> binned_boxplot(x, y, 'my x label', 'my y label')
+>
+>     ---------------------------------------------------------------------------
+>     TypeError                                 Traceback (most recent call last)
+>     <ipython-input-58-7a118d2d5750in <module>()
+>         1 x_vals = [1, 2, 3, 4, 5]
+>         2 y_vals = [1, 2, 3, 4, 5]
+>     ----3 binned_boxplot(x, y, 'my x label', 'my y label')
+>
+>     TypeError: binned_boxplot() takes 2 positional arguments but 4 were given
+>
+> The idea is to prevent you from accidentally doing something like this:
+>
+>     binned_boxplot(x, y, 'my y label')
+>
+> which would give you your y label on the x axis, and is a common error for
+> signatures with many optional parameters that don't have an obvious ordering.
 
 ```python
 log_counts = np.log(counts_lib_norm + 1)

--- a/markdown/ch2.markdown
+++ b/markdown/ch2.markdown
@@ -399,7 +399,7 @@ plot_bicluster(counts_var, yr, yc)
 We can see that the sample data naturally falls into at least 2 clusters.
 Are these clusters meaningful?
 To answer this, we can access the patient data, available from the [data repository](https://tcga-data.nci.nih.gov/docs/publications/skcm_2015/) for the paper.
-After some preprocessing, we get the [patients table]() (TODO: LINK TO FINAL PATIENTS TABLE), which contains survival information for each patient.
+After some preprocessing, we get the [patients table](https://github.com/elegant-scipy/elegant-scipy/blob/master/data/patients.csv), which contains survival information for each patient.
 We can then match these to the counts clusters, and understand whether the patients' gene expression can predict differences in their pathology.
 
 ```python

--- a/markdown/ch4.markdown
+++ b/markdown/ch4.markdown
@@ -120,7 +120,7 @@ Let's start with one of the most common applications, converting a sound signal 
 (You might have seen spectrograms on your music player's equalizer view, or even on an old-school stereo.)
 
 ![Stereo spectrogram](../images/sergey_gerasimuk_numark-eq-2600-IMG_0236.JPG)
-**[ED NOTE: Used with permission from the author, Sergey Gerasimuk, http://sgerasimuk.blogspot.com/2014/06/numark-eq-2600-10-band-stereo-graphic.html]**
+(Image used with permission from the author, Sergey Gerasimuk. Source: http://sgerasimuk.blogspot.com/2014/06/numark-eq-2600-10-band-stereo-graphic.html)
 
 Listen to the following snippet of nightingale birdsong (released under CC BY 4.0 at
 http://www.orangefreesounds.com/nightingale-sound/):


### PR DESCRIPTION
Removes a couple of to-dos from the text:

- put Python 3 keyword argument tips in a quoted "callout" box.
- fix empty link to patients table in elegant-scipy repo.
- changed an ed-note with an actual "used with permission" "caption".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elegant-scipy/elegant-scipy/207)
<!-- Reviewable:end -->
