### PR TITLE
Use networkx master to avoid matplotlib deprecation warnings

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,6 @@ dependencies:
 - scipy=0.19*
 - scikit-learn=0.18*
 - scikit-image=0.13*
-- networkx=1.11*
 - xlrd=1.0*
 - jupyter=1.0*
 - sympy=1.*
@@ -23,3 +22,5 @@ dependencies:
   - notedown>=1.5
   - jupytercontrib>=0.0.5
   - bs4
+  # need improvements from master branch
+  - pip install git+https://github.com/networkx/networkx.git


### PR DESCRIPTION
See https://github.com/networkx/networkx/pull/2397