### PR TITLE
Preserve characters trailing footnote references

### DIFF
--- a/tools/footnote_fixer.py
+++ b/tools/footnote_fixer.py
@@ -40,7 +40,6 @@ data = re.sub('^\[\^(.*?)\]: (.*?)\n(\Z|\n)', footnote_index,
 
 def insert_footnote(fid_match):
     fid = fid_match.group(1)
-
     return '<span data-type="footnote">\n{}</span>'.format(footnotes[fid])
 
-print(re.sub('\[\^(.*?)\][^:]', insert_footnote, data))
+print(re.sub('(?<!^) ?\[\^(.*?)\]', insert_footnote, data))


### PR DESCRIPTION
Also removes a space before the footnote, if it's there.  This is useful, because we often type
`see, e.g., their paper [^paper].`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elegant-scipy/elegant-scipy/276)
<!-- Reviewable:end -->
