### PR TITLE
Display only corrected image at end of ch7

### DIFF
--- a/markdown/ch7.markdown
+++ b/markdown/ch7.markdown
@@ -729,13 +729,10 @@ tf = align(green, red, cost=cost_nmi)
 cred = transform.warp(red, tf, order=3)
 
 corrected = np.dstack((cred, green, cblue))
-f, (ax0, ax1) = plt.subplots(2, 1)
-ax0.imshow(original)
-ax0.set_title('Original')
-ax1.imshow(corrected)
-ax1.set_title('Corrected')
-for ax in (ax0, ax1):
-    ax.axis('off')
+fig, ax = plt.subplots()
+ax.imshow(corrected)
+ax.set_title('NMI-Corrected')
+ax.axis('off')
 ```
 <!-- caption text="Prokudin-Gorskii channels aligned with normalized mutual
 information" -->


### PR DESCRIPTION
This will show the image at close to full-page size (one hopes), which would make it much more impactful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elegant-scipy/elegant-scipy/301)
<!-- Reviewable:end -->
