### PR TITLE
Select genes by name instead of numerical index

### DIFF
--- a/markdown/ch1.markdown
+++ b/markdown/ch1.markdown
@@ -1070,7 +1070,8 @@ We've already seen that longer genes have higher counts, but this doesn't mean t
 Let's choose a short gene and a long gene and compare their counts before and after RPKM normalization to see what we mean.
 
 ```python
-gene_idxs = np.array([80, 186])
+gene_idxs = np.nonzero((gene_names == 'RPL24') |
+                       (gene_names == 'TXNDC5'))
 gene1, gene2 = gene_names[gene_idxs]
 len1, len2 = gene_lengths[gene_idxs]
 gene_labels = [f'{gene1}, {len1}bp', f'{gene2}, {len2}bp']


### PR DESCRIPTION
It turns out that in version 0.20, pandas changed the way that index
merging happens [1]_, and now preserves the order of the *left* index,
rather than the right one. We could change the order of index merging,
but then people with pandas 0.19 would have issues. Better to make
ourselves independent of index sort order, and grab the exact genes
we want independently.

.. [1]: https://pandas.pydata.org/pandas-docs/version/0.20/whatsnew.html#index-intersection-and-inner-join-now-preserve-the-order-of-the-left-index

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elegant-scipy/elegant-scipy/326)
<!-- Reviewable:end -->
