### PR TITLE
Bug fixes for 32-bit NumPy

### DIFF
--- a/markdown/ch1.markdown
+++ b/markdown/ch1.markdown
@@ -46,9 +46,9 @@ def rpkm(counts, lengths):
     normed : array, shape (N_genes, N_samples)
         The RPKM normalized counts matrix.
     """
-    N = np.sum(counts, axis=0)  # sum each column to get total reads per sample
+    C = counts.astype(float)  # use float to avoid overflow with `1e9 * C`
+    N = np.sum(C, axis=0)  # sum each column to get total reads per sample
     L = lengths
-    C = counts
 
     normed = 1e9 * C / (N[np.newaxis, :] * L[:, np.newaxis])
 
@@ -1021,9 +1021,9 @@ def rpkm(counts, lengths):
     normed : array, shape (N_genes, N_samples)
         The RPKM normalized counts matrix.
     """
-    N = np.sum(counts, axis=0)  # sum each column to get total reads per sample
+    C = counts.astype(float)  # use float to avoid overflow with `1e9 * C`
+    N = np.sum(C, axis=0)  # sum each column to get total reads per sample
     L = lengths
-    C = counts
 
     normed = 1e9 * C / (N[np.newaxis, :] * L[:, np.newaxis])
 

--- a/markdown/ch1.markdown
+++ b/markdown/ch1.markdown
@@ -883,7 +883,42 @@ N = np.sum(counts, axis=0)  # sum each column to get total reads per sample
 L = gene_lengths  # lengths for each gene, matching rows in `C`
 ```
 
-First, we multiply by 10^9.
+> **Tip: Numbers and computers {.callout}**
+>
+> We can't cover everything you need to know about numeric representations
+> in computers in just a tip box, but you *should* know that numbers are
+> represented as "n-bit precision" "integer" or "floating point" numbers in
+> the computer. As an example, a 32-bit precision integer is an integer
+> number (no decimal point) represented as a string of 0s and 1s of width
+> 32. And, just like you can't represent a number larger than 9999 ($10^4-1$)
+> if you have a length-4 array of numbers, you can't represent a number
+> larger than $2^32 - 1 \approx 4 \times 10^9$ if you are using 32-bit
+> integers, or $2^31 - 1 \approx 2 \times 10^9$ if you want to have negative
+> numbers (because you need one of the 32 bits to indicate sign).
+>
+> So what happens when you go over that limit? You can try it with the
+> following code:
+>
+>     >>> 2**31 - 1
+>     2147483647
+>     >>> np.array([2147483647], dtype=np.int32) + 1
+>     array([-2147483648], dtype=int32)
+>
+> As you can see, it just ticks over, without warning!
+>
+> Floating point numbers can express much larger numbers, at the cost of some
+> precision:
+>
+>     >>> np.float32(2**96)
+>     7.9228163e+28
+>     >>> np.float32(2**96) == np.float32(2**96 + 1)
+>     True
+>
+> As mentioned, we can't go into all the subtleties of dealing with these
+> errors, but if you see us converting an array with `.astype(float)`, we are
+> probably dealing with these issues!
+
+First, we multiply by $10^9$.
 Because counts (C) is an ndarray, we can use broadcasting.
 If we multiple an ndarray by a single value,
 that value is broadcast over the entire array.

--- a/markdown/ch1.markdown
+++ b/markdown/ch1.markdown
@@ -866,7 +866,7 @@ If we just divide by the number of mapped reads we get:
 $ \frac{10^3C}{LN} $
 
 But biologists like thinking in millions of reads so that the numbers don't get
-too big. Counting per million reads we get:
+too small. Counting per million reads we get:
 
 $ \frac{10^3C}{L(N/10^6)} = \frac{10^9C}{LN}$
 

--- a/markdown/ch1.markdown
+++ b/markdown/ch1.markdown
@@ -889,9 +889,12 @@ If we multiple an ndarray by a single value,
 that value is broadcast over the entire array.
 
 ```python
-# Multiply all counts by 10^9
-C_tmp = 10^9 * C
+# Multiply all counts by $10^9$. Note that ^ in Python is bitwise-or.
+# Exponentiation is denoted by `**`
+# Avoid overflow by converting C to float, see tip "Numbers and computers"
+C_tmp = 10**9 * C.astype(float)
 ```
+
 Next we need to divide by the gene length.
 Broadcasting a single value over a 2D array was pretty clear.
 We were just multiplying every element in the array by the value.


### PR DESCRIPTION
The computation of RPKM in Chapter 1 overflowed when we did `1e9 * C` on 32-bit platforms, because C was a 32-bit integer array:

```python
In [21]: 1e9 * np.array([2**32-1], dtype=np.float32)
Out[21]: array([  4.29496730e+18], dtype=float32)

In [22]: 1e9 * np.array([2**32-1], dtype=np.int32)
Out[22]: array([ -1.00000000e+09])
```

I've fixed it (I think) by converting counts to float before using it in the RPKM computation.

Thank you @capissimo for the bug report (#325) and your patience while we figured it out! =) Could you please test the fix proposed in this PR?