### PR TITLE
Require `nodejs` for `npm`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
 - pillow
 - lxml
 - networkx  # make sure nx installed even if no git
+- nodejs
 - pip:
   # not available on conda, so use pip
   - notedown>=1.5


### PR DESCRIPTION
Needed to provide `npm` for installing `htmlbook`.