### PR TITLE
Use gaussian blurred image when downsampling in ch7

### DIFF
--- a/markdown/ch7.markdown
+++ b/markdown/ch7.markdown
@@ -285,7 +285,7 @@ def gaussian_pyramid(image, levels=6):
 
     for level in range(levels - 1):
         blurred = ndi.gaussian_filter(image, sigma=2/3)
-        image = downsample2x(image)
+        image = downsample2x(blurred)
         pyramid.append(image)
 
     return reversed(pyramid)


### PR DESCRIPTION
Fixes #333 

HOWEVER

Now the energy landscape is actually smooth after just 6-7 levels (instead of 8), and we no longer require `basinhopping` to get a correct alignment! :man_facepalming:  So, don't merge this yet, as it still needs a bit of experimenting to get right. Maybe we'll have to pull out the whole section on basinhopping! :sob:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elegant-scipy/elegant-scipy/334)
<!-- Reviewable:end -->
