### PR TITLE
fix error when running command docker-compose up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,5 +3,6 @@ book_builder:
   volumes:
     - .:/repo
   working_dir: /repo
-  command: make
+  command: bash -c "pip install -r requirements.txt && make"
+
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,11 @@
-FROM ubuntu:16.10
+FROM ubuntu:16.04
+
 
 RUN apt-get update && \
     apt install -y software-properties-common && \
     add-apt-repository -y ppa:fkrull/deadsnakes && \
+    add-apt-repository -y ppa:deadsnakes/ppa `# for python3.6` && \
+    apt-get update && \
     apt-get install -y python3.6 python3.6-dev curl zip \
                        libffi-dev libssl-dev npm git \
                        python-pip python-pkg-resources python-setuptools \

--- a/tools/html_image_embedder.py
+++ b/tools/html_image_embedder.py
@@ -8,6 +8,7 @@ import sys
 import os
 import encodings
 import urllib
+import urllib.request
 import bs4
 import textwrap
 


### PR DESCRIPTION
This pull request is releated to issue #329 and pull request #330

1. I use `ubuntu:16.04` instead of `ubuntu:16.10` because I always got errors when command `apt-get update` was running.

   However, python-3.6 doesn't in the ubuntu:16.04's universe repository, so I added repository manually.

   Some of python-3.6 issues, please see [ref](https://askubuntu.com/questions/865554/how-do-i-install-python-3-6-using-apt-get).

2. After repository is added, command `apt-get update` should run again.

3. `docker-compose up` would complain `/bin/bash: notedown: command not found` since tools are related to python does not install in docker image or in `docker-compose.yml`.

4. Fix for error `AttributeError: module 'urllib' has no attribute 'error'` when compiling file `tools/html_image_embedder.py`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elegant-scipy/elegant-scipy/339)
<!-- Reviewable:end -->
