### PR TITLE
BUG: Fixed error in ch3 code due to networkx API change.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,11 +17,9 @@ dependencies:
 - beautifulsoup4=4.5*
 - pillow
 - lxml
-- networkx  # make sure nx installed even if no git
+- networkx=2.4*
 - pip:
   # not available on conda, so use pip
   - notedown>=1.5
   - jupytercontrib>=0.0.5
   - bs4
-  # need improvements from master branch
-  - git+https://github.com/networkx/networkx.git

--- a/markdown/ch3.markdown
+++ b/markdown/ch3.markdown
@@ -757,7 +757,7 @@ NetworkX makes straightforward work out of getting the largest strongly
 connected component from our `wormbrain` network:
 
 ```python
-sccs = nx.strongly_connected_component_subgraphs(wormbrain)
+sccs = (wormbrain.subgraph(c) for c in nx.strongly_connected_components(wormbrain))
 giantscc = max(sccs, key=len)
 print(f'The largest strongly connected component has '
       f'{giantscc.number_of_nodes()} nodes, out of '
@@ -1091,12 +1091,12 @@ def build_rag(labels, image):
     _ = ndi.generic_filter(labels, add_edge_filter, footprint=footprint,
                            mode='nearest', extra_arguments=(g,))
     for n in g:
-        g.node[n]['total color'] = np.zeros(3, np.double)
-        g.node[n]['pixel count'] = 0
+        g.nodes[n]['total color'] = np.zeros(3, np.double)
+        g.nodes[n]['pixel count'] = 0
     for index in np.ndindex(labels.shape):
         n = labels[index]
-        g.node[n]['total color'] += image[index]
-        g.node[n]['pixel count'] += 1
+        g.nodes[n]['total color'] += image[index]
+        g.nodes[n]['pixel count'] += 1
     return g
 ```
 
@@ -1120,10 +1120,10 @@ Now, we can use everything we've learned to segment the tiger in the image above
 ```python
 g = build_rag(seg, tiger)
 for n in g:
-    node = g.node[n]
+    node = g.nodes[n]
     node['mean'] = node['total color'] / node['pixel count']
 for u, v in g.edges():
-    d = g.node[u]['mean'] - g.node[v]['mean']
+    d = g.nodes[u]['mean'] - g.nodes[v]['mean']
     g[u][v]['weight'] = np.linalg.norm(d)
 ```
 

--- a/markdown/ch5.markdown
+++ b/markdown/ch5.markdown
@@ -1475,12 +1475,12 @@ def build_rag(labels, image):
     _ = ndi.generic_filter(labels, add_edge_filter, footprint=footprint,
                           mode='nearest', extra_arguments=(g,))
     for n in g:
-        g.node[n]['total color'] = np.zeros(3, np.double)
-        g.node[n]['pixel count'] = 0
+        g.nodes[n]['total color'] = np.zeros(3, np.double)
+        g.nodes[n]['pixel count'] = 0
     for index in np.ndindex(labels.shape):
         n = labels[index]
-        g.node[n]['total color'] += image[index]
-        g.node[n]['pixel count'] += 1
+        g.nodes[n]['total color'] += image[index]
+        g.nodes[n]['pixel count'] += 1
     return g
 
 def threshold_graph(g, t):
@@ -1506,10 +1506,10 @@ Let's pop the segmentation code into a function so we can play with it.
 def rag_segmentation(base_seg, image, threshold=80):
     g = build_rag(base_seg, image)
     for n in g:
-        node = g.node[n]
+        node = g.nodes[n]
         node['mean'] = node['total color'] / node['pixel count']
     for u, v in g.edges():
-        d = g.node[u]['mean'] - g.node[v]['mean']
+        d = g.nodes[u]['mean'] - g.nodes[v]['mean']
         g[u][v]['weight'] = np.linalg.norm(d)
 
     threshold_graph(g, threshold)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scipy>=0.17
 matplotlib>=2.0.0
 scikit-image>=0.13
 toolz
-networkx
+networkx>=2.4
 xlrd
 pandas
 scikit-learn


### PR DESCRIPTION
networkx introduced non-backwards-compatible API changes in version 2.4. Several of these changes introduced bugs when running the code cells in chapter 3. The following changes resolved the issue:

 * Replaced `strongly_connected_component_subgraphs` with suggested code from networkx-2.4 release notes

 * Replaced `node` attribute of Graph objects with `nodes` per networkx-2.4 release notes

 * Updated the environment files to take the new networkx version dependency into account.

Related documentation: [networkx version 2.4 release notes](https://github.com/networkx/networkx/blob/master/doc/release/release_2.4.rst)