### PR TITLE
BUG: import alias inconsistency of scipy.ndimage in ch. 3

### DIFF
--- a/markdown/ch3.markdown
+++ b/markdown/ch3.markdown
@@ -44,7 +44,7 @@ a filter from SciPy's N-dimensional image processing submodule, `ndimage`.
 ```python
 import networkx as nx
 import numpy as np
-from scipy import ndimage as nd
+from scipy import ndimage as ndi
 
 def add_edge_filter(values, graph):
     center = values[len(values) // 2]
@@ -1075,7 +1075,7 @@ arguments to the filter function, and we can use that to build the graph:
 ```python
 import networkx as nx
 import numpy as np
-from scipy import ndimage as nd
+from scipy import ndimage as ndi
 
 def add_edge_filter(values, graph):
     center = values[len(values) // 2]


### PR DESCRIPTION
The first code cell in ch. 3 is explanatory only, but if the user
tried to run the code they would get an error because the import
statement aliases `ndimage` to `nd` but subsequent code refers to
the module as `ndi`

This occurs in the final code cells as well, but an exception is
avoided there because there is one cell where `ndimage` is imported
as `ndi`.

This commit fixes the issue by making the `ndimage` import aliasing
consistent throughout the document.