### PR TITLE
ENH: Modified FFT windowing example.

### DIFF
--- a/markdown/ch4.markdown
+++ b/markdown/ch4.markdown
@@ -800,13 +800,10 @@ lobes ($\beta$ typically between 5 and 10) [^choosing_a_window].
                       application, as illustrated in the main text, by
                       adjusting the parameter $\beta$.
 
-Applying the Kaiser window here, we see that the sidelobes have been
-drastically reduced, at the cost of a slight widening in the main lobe.
-
 <!--
 *For online notebook, use something like:*
 
-```
+#```
 # @interact(beta=(0, 20.))
 # def window(beta):
 #    x = np.kaiser(1000, beta)
@@ -815,17 +812,24 @@ drastically reduced, at the cost of a slight widening in the main lobe.
 #    axes[1].plot(fftpack.fftshift(np.abs(np.fft.fft(x, 10000))))
 #    axes[1].set_xlim(2*2480, 2*2520)
 #    plt.show()
-```
+#```
 -->
 
 The effect of windowing our previous example is noticeable:
 
 ```python
 win = np.kaiser(len(t), 5)
-X_win = fftpack.fft(x * win)
+x_win = x * win
 
-plt.plot(fftpack.fftfreq(len(t)), np.abs(X_win))
-plt.ylim(0, 190);
+X_win = fftpack.fft(x_win)
+
+f, (ax0, ax1) = plt.subplots(2, 1)
+
+ax0.plot(x_win)
+ax0.set_ylim(-1.1, 1.1)
+
+ax1.plot(fftpack.fftfreq(len(t)), np.abs(X_win))
+ax1.set_ylim(0, 190);
 ```
 <!-- caption text="Spectrum of a windowed signal (magnitude)" -->
 


### PR DESCRIPTION
Made several changes around the kaiser-windowing fft example in ch. 4.

 * Removed redundant sentence (seems like it was referring to the
   wrong example)
 * Added comments to un-break hiding of code block that was not
   intended to be shown
 * Modified windowed-fft plotting example to match the previous
   example against which it is intended to be compared.