### PR TITLE
ENH: Re-fftshift masked magnitude for final display.

### DIFF
--- a/markdown/ch4.markdown
+++ b/markdown/ch4.markdown
@@ -686,7 +686,7 @@ F_dim = F_dim * peaks.astype(int)
 image_filtered = np.real(fftpack.ifft2(F_dim))
 
 f, (ax0, ax1) = plt.subplots(2, 1, figsize=(4.8, 7))
-ax0.imshow(np.log10(1 + np.abs(F_dim)), cmap='viridis')
+ax0.imshow(fftpack.fftshift(np.log10(1 + np.abs(F_dim))), cmap='viridis')
 ax0.set_title('Spectrum after suppression')
 
 ax1.imshow(image_filtered)


### PR DESCRIPTION
The original spectrum magnitude is shown fftshift-ed while the
spectrum magnitude after filtering is shown un-shifted.
Re-shifted the spectrum magnitude after filtering (for display only)
so that the result of the filtering is more easily demonstrated in
visual comparison of the two figures.